### PR TITLE
Fix templating uri patterns exclusion

### DIFF
--- a/datadome-istio/templates/envoyfilter.yaml
+++ b/datadome-istio/templates/envoyfilter.yaml
@@ -35,15 +35,19 @@ spec:
                   {{- . | quote -}},
                 {{ end -}}
               },
+              {{- if .Values.datadome.uri_patterns -}}
               URI_PATTERNS = {
                 {{ range .Values.datadome.uri_patterns }}
                   {{- . | quote -}},
                 {{ end -}}
               },
+              {{ end }}
+              {{- if .Values.datadome.uri_patterns_exclusion -}}
               URI_PATTERNS_EXCLUSION = {
                 {{ range .Values.datadome.uri_patterns_exclusion }}
                   {{- . | quote -}},
                 {{ end -}}
               }
+              {{ end }}
             }
             {{- tpl (.Files.Get "files/datadome.lua") . | nindent 12 }}

--- a/datadome-istio/values.yaml
+++ b/datadome-istio/values.yaml
@@ -16,4 +16,3 @@ datadome:
   - '^edge.blablacar.com'
   - '^http%-echo.staging%-1.blbl.cr'
   uri_patterns:
-  uri_exclusion_patterns:


### PR DESCRIPTION
empty table in lua actually is truthy.
This fixes the defaulting of filters