### PR TITLE
[compat] use typed_config for istio 1.7+ compatibility

### DIFF
--- a/datadome-istio/templates/envoyfilter.yaml
+++ b/datadome-istio/templates/envoyfilter.yaml
@@ -25,7 +25,8 @@ spec:
       operation: INSERT_BEFORE
       value:
         name: envoy.lua
-        config:
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
           inlineCode: |
             local options = {
               API_TIMEOUT = {{ .Values.datadome.api_timeout}},


### PR DESCRIPTION
all config filed must be updated to typed_config.

Note that it might be needed to also upgrade to api v3 for istio 1.7.
Check the envoy version associated with it with istioctl pc bootstrap &
check envoy documentation for deprecation notices