### PR TITLE
[BBC-27104] don't add cookie if response is cacheable

### DIFF
--- a/datadome-istio/Chart.yaml
+++ b/datadome-istio/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: datadome-istio
-version: 0.3.5
+version: 0.4.0


### PR DESCRIPTION
> [BBC-27104]

## Description

See https://blablacar.atlassian.net/wiki/spaces/SPA/pages/2816180604/Design+Doc+Static+Pages+vs+Datadome

If upstream response is cacheable according to its `Cache-Control` header, we should not add a Datadome cookie on top (via `Set-Cookie`), as it would make the response non-cacheable for downstream service (eg. CDN).

[BBC-27104]: https://blablacar.atlassian.net/browse/BBC-27104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ