### PR TITLE
[/datadome-istio] Adding per-filter context

### DIFF
--- a/datadome-istio/Chart.yaml
+++ b/datadome-istio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "1.3.1"
 description: A Helm chart for Kubernetes
 name: datadome-istio
-version: 0.4.0
+version: 0.4.1

--- a/datadome-istio/files/datadome.lua
+++ b/datadome-istio/files/datadome.lua
@@ -1,5 +1,7 @@
 local DATADOME_API_KEY = options['API_KEY']
 
+local DATADOME_FILTER_NAME = options['FILTER_NAME']
+
 local DATADOME_API_TIMEOUT = options['API_TIMEOUT'] or 100
 
 local DATADOME_URL_PATTERNS = options['URL_PATTERNS'] or {}
@@ -326,7 +328,7 @@ function envoy_on_request(request_handle)
     end
     local dynamicMetadata = request_handle:streamInfo():dynamicMetadata()
     for response_header, _ in pairs(response_headers) do
-      dynamicMetadata:set("datadome-response-headers", response_header, headers[response_header])
+      dynamicMetadata:set(DATADOME_FILTER_NAME, response_header, headers[response_header])
     end
   end
 end
@@ -341,7 +343,7 @@ function envoy_on_response(response_handle)
 	end
 
   local dynamicMetadata = response_handle:streamInfo():dynamicMetadata()
-  local datadomeResponseHeaders = dynamicMetadata:get("datadome-response-headers") or {}
+  local datadomeResponseHeaders = dynamicMetadata:get(DATADOME_FILTER_NAME) or {}
   for key, value in pairs(datadomeResponseHeaders) do
     if key == "set-cookie" then
       response_handle:headers():add(key, value)

--- a/datadome-istio/files/datadome.lua
+++ b/datadome-istio/files/datadome.lua
@@ -49,7 +49,7 @@ local DATADOME_URI_PATTERNS_EXCLUSION = options['URI_PATTERNS_EXCLUSION'] or {
 
 local DATADOME_MODULE_NAME="Envoy"
 
-local DATADOME_MODULE_VERSION="1.3.0"
+local DATADOME_MODULE_VERSION="1.3.1"
 
 local DATADOME_REQUEST_PORT=0
 
@@ -257,6 +257,7 @@ function envoy_on_request(request_handle)
       ["AcceptEncoding"]         = headers:get("accept-encoding"),
       ["AcceptLanguage"]         = headers:get("accept-language"),
       ["AcceptCharset"]          = headers:get("accept-charset"),
+      ["ContentType"]            = headers:get("content-type"),
       ["Origin"]                 = headers:get("origin"),
       ["XForwardedForIP"]        = headers:get("x-forwarded-for"),
       ["X-Requested-With"]       = headers:get("x-requested-with"),

--- a/datadome-istio/templates/envoyfilter.yaml
+++ b/datadome-istio/templates/envoyfilter.yaml
@@ -28,11 +28,12 @@ spec:
     patch:
       operation: INSERT_BEFORE
       value:
-        name: envoy.lua
+        name: {{ .Release.Name }}.lua
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
           inlineCode: |
             local options = {
+              FILTER_NAME = '{{ .Release.Name }}',
               API_TIMEOUT = {{ .Values.datadome.api_timeout}},
               API_KEY = '{{ .Values.datadome.api_key }}',
               URL_PATTERNS = {


### PR DESCRIPTION
**Context**
 If this HR is deployed 3 times, then 3 * identical `Set-cookie` headers are added to every datadome response.

**The issue**
The `envoy_on_response` function which is present in every instance is executed for every response received by envoy, hence the 3 * headers.
 
**The fix**
Now the response headers are added under a separate key (one per HR instance), which allows to have a separate context per namespace.