### PR TITLE
infra(xff-validation): add 'x-envoy-external-address' & 'x-envoy-internal' HTTP headers values in the Datadome request body

### DIFF
--- a/datadome-istio/files/datadome.lua
+++ b/datadome-istio/files/datadome.lua
@@ -49,7 +49,7 @@ local DATADOME_URI_PATTERNS_EXCLUSION = options['URI_PATTERNS_EXCLUSION'] or {
 
 local DATADOME_MODULE_NAME="Envoy"
 
-local DATADOME_MODULE_VERSION="1.3.2"
+local DATADOME_MODULE_VERSION="1.3.3-a"
 
 local DATADOME_REQUEST_PORT=0
 
@@ -281,6 +281,8 @@ function envoy_on_request(request_handle)
       ["SecFetchMode"]           = headers:get("Sec-Fetch-Mode"),
       ["SecFetchSite"]           = headers:get("Sec-Fetch-Site"),
       ["SecFetchUser"]           = headers:get("Sec-Fetch-User"),
+      ["TrueClientIP"]           = headers:get("x-envoy-external-address"),
+      ["X-Real-IP"]              = headers:get("x-envoy-internal"),
     })
   )
 


### PR DESCRIPTION
This PR adds the `x-envoy-external-address` & `x-envoy-internal` HTTP headers to the Datadome request in order to let Datadome validate the content and then update the XFF validation system